### PR TITLE
Fix End Turn Command

### DIFF
--- a/BWS_Turn_System/bws-turn-order.js
+++ b/BWS_Turn_System/bws-turn-order.js
@@ -367,7 +367,9 @@ var BWSTurnSystem = {
 		
 		for (i = 0; i < turnListCount; i++) {
 			if (this.turnList[i] === TurnType.PLAYER) {
-				this.turnList.splice(i, 1);	
+				this.turnList.splice(i, 1);
+				//Check the same index again after splicing, when the list has no players the loop ends.
+				i--
 			}
 		}
 		


### PR DESCRIPTION
Currently, if one uses the End Turn command the game can soft-lock when the list only contains player units due to the splicing of the list modifying the array and the for loop advancing over the replaced values.

With this fix, any time a unit is removed from the list, the loop checks the same index again to see if the value is another player unit, when no player units remain the loop ends.